### PR TITLE
Fix old urls referencing old github handle

### DIFF
--- a/0-limit-crawler/README.md
+++ b/0-limit-crawler/README.md
@@ -19,7 +19,7 @@ Use `go test` to verify if your solution is correct.
 Correct solution:
 ```
 PASS
-ok      github.com/mindworker/go-concurrency-exercises/0-limit-crawler  13.009s
+ok      github.com/loong/go-concurrency-exercises/0-limit-crawler  13.009s
 ```
 
 Incorrect solution:
@@ -29,5 +29,5 @@ Incorrect solution:
 	        main_test.go:19: Solution is incorrect.
 		FAIL
 		exit status 1
-		FAIL    github.com/mindworker/go-concurrency-exercises/0-limit-crawler  7.808s
+		FAIL    github.com/loong/go-concurrency-exercises/0-limit-crawler  7.808s
 ```

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The Go community has plenty resources to read about go's concurrency model and h
 ## Overview
 | # | Name of the Challenge + URL           | 
 | - |:-------------|
-| 0 | [Limit your Crawler](https://github.com/loong/go-concurrency-exercises/tree/master/0-limit-crawler) |
-| 1 | [Producer-Consumer](https://github.com/loong/go-concurrency-exercises/tree/master/1-producer-consumer)  |
-| 2 | [Race Condition in Caching Cache](https://github.com/loong/go-concurrency-exercises/tree/master/2-race-in-cache#race-condition-in-caching-szenario)  |
-| 3 | [Limit Service Time for Free-tier Users](https://github.com/loong/go-concurrency-exercises/tree/master/3-limit-service-time)  |
-| 4 | [Graceful SIGINT Killing](https://github.com/loong/go-concurrency-exercises/tree/master/4-graceful-sigint)  |
-| 5 | [Clean Inactive Sessions to Prevent Memory Overflow](https://github.com/loong/go-concurrency-exercises/tree/master/5-session-cleaner)  |
+| 0 | [Limit your Crawler](https://github.com/loong/go-concurrency-exercises/tree/main/0-limit-crawler) |
+| 1 | [Producer-Consumer](https://github.com/loong/go-concurrency-exercises/tree/main/1-producer-consumer)  |
+| 2 | [Race Condition in Caching Cache](https://github.com/loong/go-concurrency-exercises/tree/main/2-race-in-cache#race-condition-in-caching-szenario)  |
+| 3 | [Limit Service Time for Free-tier Users](https://github.com/loong/go-concurrency-exercises/tree/main/3-limit-service-time)  |
+| 4 | [Graceful SIGINT Killing](https://github.com/loong/go-concurrency-exercises/tree/main/4-graceful-sigint)  |
+| 5 | [Clean Inactive Sessions to Prevent Memory Overflow](https://github.com/loong/go-concurrency-exercises/tree/main/5-session-cleaner)  |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Concurrency Exercises [![Build Status](https://travis-ci.org/mindworker/go-concurrency-exercises.svg?branch=master)](https://travis-ci.org/mindworker/go-concurrency-exercises) [![Go Report Card](https://goreportcard.com/badge/github.com/mindworker/go-concurrency-exercises)](https://goreportcard.com/report/github.com/mindworker/go-concurrency-exercises)
+# Go Concurrency Exercises [![Build Status](https://travis-ci.org/loong/go-concurrency-exercises.svg?branch=main)](https://travis-ci.org/loong/go-concurrency-exercises) [![Go Report Card](https://goreportcard.com/badge/github.com/loong/go-concurrency-exercises)](https://goreportcard.com/report/github.com/loong/go-concurrency-exercises)
 Exercises for Golang's concurrency patterns.
 
 ## Why
@@ -14,12 +14,12 @@ The Go community has plenty resources to read about go's concurrency model and h
 ## Overview
 | # | Name of the Challenge + URL           | 
 | - |:-------------|
-| 0 | [Limit your Crawler](https://github.com/mindworker/go-concurrency-exercises/tree/master/0-limit-crawler) |
-| 1 | [Producer-Consumer](https://github.com/mindworker/go-concurrency-exercises/tree/master/1-producer-consumer)  |
-| 2 | [Race Condition in Caching Cache](https://github.com/mindworker/go-concurrency-exercises/tree/master/2-race-in-cache#race-condition-in-caching-szenario)  |
-| 3 | [Limit Service Time for Free-tier Users](https://github.com/mindworker/go-concurrency-exercises/tree/master/3-limit-service-time)  |
-| 4 | [Graceful SIGINT Killing](https://github.com/mindworker/go-concurrency-exercises/tree/master/4-graceful-sigint)  |
-| 5 | [Clean Inactive Sessions to Prevent Memory Overflow](https://github.com/mindworker/go-concurrency-exercises/tree/master/5-session-cleaner)  |
+| 0 | [Limit your Crawler](https://github.com/loong/go-concurrency-exercises/tree/master/0-limit-crawler) |
+| 1 | [Producer-Consumer](https://github.com/loong/go-concurrency-exercises/tree/master/1-producer-consumer)  |
+| 2 | [Race Condition in Caching Cache](https://github.com/loong/go-concurrency-exercises/tree/master/2-race-in-cache#race-condition-in-caching-szenario)  |
+| 3 | [Limit Service Time for Free-tier Users](https://github.com/loong/go-concurrency-exercises/tree/master/3-limit-service-time)  |
+| 4 | [Graceful SIGINT Killing](https://github.com/loong/go-concurrency-exercises/tree/master/4-graceful-sigint)  |
+| 5 | [Clean Inactive Sessions to Prevent Memory Overflow](https://github.com/loong/go-concurrency-exercises/tree/master/5-session-cleaner)  |
 
 ## License
 


### PR DESCRIPTION
Noticed quite a few of the URLs where pointing at the old GitHub handle `mindworker`. Which among other things broke the travis build badge.

<img width="929" alt="Screenshot 2022-10-30 at 5 27 31 PM" src="https://user-images.githubusercontent.com/1732217/198871693-d1f24915-00c6-449b-ab76-6c209d2d092d.png">

Also realized, that there are some links pointing at the old `master` branch instead of `main`.