### PR TITLE
Fixing a minor bug in Excercise 4

### DIFF
--- a/4-graceful-sigint/mockprocess.go
+++ b/4-graceful-sigint/mockprocess.go
@@ -9,17 +9,21 @@ package main
 import (
 	"fmt"
 	"log"
+	"sync"
 	"time"
 )
 
 // MockProcess for example
 type MockProcess struct {
+	mu sync.Mutex
 	isRunning bool
 }
 
 // Run will start the process
 func (m *MockProcess) Run() {
+	m.mu.Lock()
 	m.isRunning = true
+	m.mu.Unlock()
 
 	fmt.Print("Process running..")
 	for {
@@ -31,6 +35,8 @@ func (m *MockProcess) Run() {
 // Stop tries to gracefully stop the process, in this mock example
 // this will not succeed
 func (m *MockProcess) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if !m.isRunning {
 		log.Fatal("Cannot stop a process which is not running")
 	}


### PR DESCRIPTION
This fixes a race happening in the mock of `4-graceful-sigint`:

```
$ cd 4-graceful-sigint
$ go run -race .
Process running...^C==================
WARNING: DATA RACE
Read at 0x00c00001415f by goroutine 10:
  main.(*MockProcess).Stop()
      4-graceful-sigint/mockprocess.go:34 +0x30
  main.main.func3()
      4-graceful-sigint/main.go:38 +0x33

Previous write at 0x00c00001415f by goroutine 9:
  main.(*MockProcess).Run()
      4-graceful-sigint/mockprocess.go:22 +0x30
  main.main.func2()
      4-graceful-sigint/main.go:31 +0x33

Goroutine 10 (running) created at:
  main.main()
      4-graceful-sigint/main.go:38 +0x267

Goroutine 9 (running) created at:
  main.main()
      4-graceful-sigint/main.go:31 +0x165
==================
```

Functionality not changed.