### PR TITLE
Fix the link to the RateLimiting Go wiki page

### DIFF
--- a/0-limit-crawler/README.md
+++ b/0-limit-crawler/README.md
@@ -10,7 +10,7 @@ Crawl() must be called concurrently)
 
 This exercise can be solved in 3 lines only. If you can't do
 it, have a look at this:
-https://github.com/golang/go/wiki/RateLimiting
+https://go.dev/wiki/RateLimiting
 
 ## Test your solution
 


### PR DESCRIPTION
The PR fixes the link to the [RateLimiting](https://go.dev/wiki/RateLimiting) Go wiki page.

The Go wiki on GitHub has moved to go.dev in the golang/go#61940.