### PR TITLE
feat: implement limit crawler solution

### DIFF
--- a/0-limit-crawler/main.go
+++ b/0-limit-crawler/main.go
@@ -12,8 +12,10 @@ package main
 import (
 	"fmt"
 	"sync"
+	"time"
 )
 
+var ticker = time.Tick(1 * time.Second)
 // Crawl uses `fetcher` from the `mockfetcher.go` file to imitate a
 // real crawler. It crawls until the maximum depth has reached.
 func Crawl(url string, depth int, wg *sync.WaitGroup) {
@@ -23,6 +25,7 @@ func Crawl(url string, depth int, wg *sync.WaitGroup) {
 		return
 	}
 
+	<-ticker // only one go-routine will extract the time from the ticker channel
 	body, urls, err := fetcher.Fetch(url)
 	if err != nil {
 		fmt.Println(err)
@@ -41,7 +44,7 @@ func Crawl(url string, depth int, wg *sync.WaitGroup) {
 
 func main() {
 	var wg sync.WaitGroup
-
+	
 	wg.Add(1)
 	Crawl("http://golang.org/", 4, &wg)
 	wg.Wait()


### PR DESCRIPTION
- Added global ticker to rate limit crawling to 1 page/sec
- Maintains concurrency via go-routines
- Used shared channel for throttling